### PR TITLE
Remove `Twig` shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ for experienced git users.
 
 ## Usage
 
-Invoke Twiggy with the `:Twiggy`, or simply `:Twig` command.
+Invoke Twiggy with the `:Twiggy` command.
 
 Use `j` and `k` to jump between branch names and `<C-N>` and `<C-P>` to jump
 between groups.  As your cursor moves, information about the branch under the
@@ -61,7 +61,7 @@ press `M`.
 
 `dd` to delete a branch.  You will be prompted if it's unmerged.
 
-Create or checkout a branch with `:Twig <branch-name>`.
+Create or checkout a branch with `:Twiggy <branch-name>`.
 
 Type `q` to quit.
 

--- a/plugin/twiggy.vim
+++ b/plugin/twiggy.vim
@@ -8,7 +8,4 @@ if exists('g:loaded_twiggy') || &cp
 endif
 let g:loaded_twiggy = 1
 
-for cmd in ['Twiggy', 'Twig']
-  exec "command! -nargs=* -complete=custom,TwiggyCompleteGitBranches " .
-        \ cmd . " call twiggy#Branch(<f-args>)"
-endfor
+command -nargs=* -complete=custom,TwiggyCompleteGitBranches Twiggy call twiggy#Branch(<f-args>)


### PR DESCRIPTION
Vim allows commands to be run with any unambiguous prefix, so `:Twig`
can be used to invoke this without special handling. In fact, in common
setups, if this shortcut is removed even just `:Tw` can be used.