### PR TITLE
buffer stuff

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -711,7 +711,7 @@ function! s:Render() abort
     else
       exec 'silent keepalt' g:twiggy_split_position g:twiggy_num_columns . 'vsplit' fname
     endif
-    setlocal filetype=twiggy buftype=nofile
+    setlocal filetype=twiggy buftype=nofile bufhidden=delete
     setlocal nonumber nowrap lisp
     let t:twiggy_bufnr = bufnr('')
   endif


### PR DESCRIPTION
Maybe found out what was happening with the branches buffer not going away when opening quickhelp.

I think it has something to do with me having "set hidden" in my config which doesn't delete buffers by default. I noticed that in the quickhelp function you were setting bufhidden=delete so I tried it out here and it seems to do the trick. I've never really done any vim plugin stuff or contributed to any public repositories, so let me know if I'm doing anything wrong :) Hopefully this at least helps a little.

Also the issue that this (hopefully) fixes is here: https://github.com/sodapopcan/vim-twiggy/issues/9