### PR TITLE
Fix fugitive#buffer() deprecated

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -142,7 +142,7 @@ function! s:gitize(cmd) abort
   if exists('t:twiggy_bufnr') && t:twiggy_bufnr == bufnr('')
     let git_cmd = t:twiggy_git_cmd
   else
-    let git_cmd = fugitive#buffer().repo().git_command()
+    let git_cmd = fugitive#repo().git_command()
   end
   return git_cmd . ' ' . a:cmd
 endfunction
@@ -762,7 +762,7 @@ function! s:Render() abort
 
   if exists('b:git_dir') && &filetype !=# 'twiggy'
     let t:twiggy_git_dir = b:git_dir
-    let t:twiggy_git_cmd = fugitive#buffer().repo().git_command()
+    let t:twiggy_git_cmd = fugitive#repo().git_command()
   elseif !exists('t:twiggy_git_cmd')
     echo "Not a git repository"
     return
@@ -1034,7 +1034,7 @@ function! s:Refresh() abort
   let t:refreshing = 1
   if &filetype !=# 'twiggy'
     let t:twiggy_git_dir = b:git_dir
-    let t:twiggy_git_cmd = fugitive#buffer().repo().git_command()
+    let t:twiggy_git_cmd = fugitive#repo().git_command()
     call s:buffocus(t:twiggy_bufnr)
   endif
   call s:Render()
@@ -1064,7 +1064,7 @@ function! twiggy#Branch(...) abort
       else
         " If twiggy is open, :Twiggy will focus the twiggy buffer then redraw " it
         let t:twiggy_git_dir = b:git_dir
-        let t:twiggy_git_cmd = fugitive#buffer().repo().git_command()
+        let t:twiggy_git_cmd = fugitive#repo().git_command()
         call s:buffocus(t:twiggy_bufnr)
       end
     endif


### PR DESCRIPTION
`fugitive#buffer()` has recently been deprecated: 

https://github.com/tpope/vim-fugitive/commit/d41dee9c0b0cd2ffc364f2784d764b76e43ae057

This PR removes this call to buffer within several of vim-twiggy's functions.