### PR TITLE
Move mappings, syntax, etc. into ftplugin and syntax folders

### DIFF
--- a/ftplugin/twiggy-cherry-pick.vim
+++ b/ftplugin/twiggy-cherry-pick.vim
@@ -1,0 +1,2 @@
+call twiggy#local_mapping('s', 'Continue', ['cherry-pick'])
+call twiggy#local_mapping('a', 'Abort', ['cherry-pick'])

--- a/ftplugin/twiggy-help.vim
+++ b/ftplugin/twiggy-help.vim
@@ -1,0 +1,2 @@
+nnoremap <buffer> <silent> q :quit<CR>
+nnoremap <buffer> <silent> ? :Twiggy<CR>

--- a/ftplugin/twiggy-merge.vim
+++ b/ftplugin/twiggy-merge.vim
@@ -1,0 +1,1 @@
+call twiggy#local_mapping('a', 'Abort', ['merge'])

--- a/ftplugin/twiggy-output.vim
+++ b/ftplugin/twiggy-output.vim
@@ -1,0 +1,2 @@
+nnoremap <buffer> q :quit<CR>
+nnoremap <buffer> Q :quit<CR>:call twiggy#Close()<CR>

--- a/ftplugin/twiggy-rebase.vim
+++ b/ftplugin/twiggy-rebase.vim
@@ -1,0 +1,3 @@
+call twiggy#local_mapping('c', 'Continue', ['rebase'])
+call twiggy#local_mapping('s', 'Skip', [])
+call twiggy#local_mapping('a', 'Abort', ['rebase'])

--- a/ftplugin/twiggy.vim
+++ b/ftplugin/twiggy.vim
@@ -1,0 +1,71 @@
+setlocal buftype=nofile bufhidden=delete nonumber nowrap noswapfile lisp nomodifiable
+
+augroup twiggy
+    autocmd! * <buffer>
+    autocmd CursorMoved <buffer> call twiggy#show_branch_details()
+    autocmd CursorMoved <buffer> call twiggy#update_last_branch_under_cursor()
+    autocmd BufReadPost,BufEnter,VimResized twiggy://* call twiggy#Refresh()
+    autocmd BufWinLeave <buffer>
+        \ if exists('t:twiggy_bufnr') |
+        \   unlet! t:twiggy_bufnr |
+        \   unlet! t:twiggy_git_dir |
+        \   unlet! t:twiggy_git_cmd |
+        \   unlet! t:twiggy_git_mode |
+        \ endif
+augroup END
+
+let close_string = g:twiggy_close_on_fugitive_cmd ? 'call twiggy#Close()' : 'wincmd w'
+exec "command! -buffer Gstatus " . close_string . " | silent normal! :<\C-U>Gstatus\<CR>"
+exec "command! -buffer Gcommit " . close_string . " | silent normal! :<\C-U>Gcommit\<CR>"
+exec "command! -buffer Gblame  " . close_string . " | silent normal! :<\C-U>Gblame\<CR>"
+
+nnoremap <buffer> <silent> q :<C-U>call twiggy#Close()<CR>
+if g:twiggy_enable_quickhelp
+    nnoremap <buffer> <silent> ? :<C-U>call twiggy#Quickhelp()<CR>
+endif
+
+nnoremap <buffer> <silent> j      :<C-U>call twiggy#traverse_branches('j')<CR>
+nnoremap <buffer> <silent> k      :<C-U>call twiggy#traverse_branches('k')<CR>
+nnoremap <buffer> <silent> <Down> :<C-U>call twiggy#traverse_branches('j')<CR>
+nnoremap <buffer> <silent> <Up>   :<C-U>call twiggy#traverse_branches('k')<CR>
+nnoremap <buffer> <silent> <C-N>  :<C-U>call twiggy#traverse_groups('j')<CR>
+nnoremap <buffer> <silent> <C-P>  :<C-U>call twiggy#traverse_groups('k')<CR>
+nnoremap <buffer> <silent> J      :<C-U>call twiggy#jump_to_current_branch()<CR>
+if twiggy#showing_full_ui()
+    nnoremap <buffer> <silent> gg :normal! 4gg<CR>
+else
+    nnoremap <buffer> <silent> gg :normal! 2gg<CR>
+endif
+
+call twiggy#local_mapping('<CR>','Checkout',  [1])
+call twiggy#local_mapping('C',   'Checkout',  [0])
+call twiggy#local_mapping('o',   'Checkout',  [1])
+call twiggy#local_mapping('O',   'Checkout',  [0])
+call twiggy#local_mapping('dd',  'Delete',    [])
+call twiggy#local_mapping('F',   'Fetch',     [0])
+call twiggy#local_mapping('m',   'Merge',     [0, ''])
+call twiggy#local_mapping('M',   'Merge',     [1, ''])
+call twiggy#local_mapping('gm',  'Merge',     [0, '--no-ff'])
+call twiggy#local_mapping('gM',  'Merge',     [1, '--no-ff'])
+call twiggy#local_mapping('r',   'Rebase',    [0])
+call twiggy#local_mapping('R',   'Rebase',    [1])
+call twiggy#local_mapping('^',   'Push',      [0, 0])
+call twiggy#local_mapping('g^',  'Push',      [1, 0])
+call twiggy#local_mapping('!^',  'Push',      [0, 1])
+call twiggy#local_mapping('V',   'Pull',      [])
+" call twiggy#local_mapping(',',   'Rename',    [])
+call twiggy#local_mapping('<<',  'Stash',     [0])
+call twiggy#local_mapping('>>',  'Stash',     [1])
+call twiggy#local_mapping('i',   'CycleSort', [0, 1])
+call twiggy#local_mapping('I',   'CycleSort', [0, -1])
+call twiggy#local_mapping('gi',  'CycleSort', [1, 1])
+call twiggy#local_mapping('gI',  'CycleSort', [1, -1])
+
+if g:twiggy_git_log_command !=# ''
+    nnoremap <buffer> gl :exec ':' . g:twiggy_git_log_command . ' ' . twiggy#branch_under_cursor().fullname<CR>
+    nnoremap <buffer> gL :exec ':' . g:twiggy_git_log_command . ' ' . twiggy#branch_under_cursor().fullname . '..'<CR>
+endif
+
+if g:twiggy_enable_remote_delete
+    call twiggy#local_mapping('d^', 'DeleteRemote', [])
+endif

--- a/syntax/twiggy-cherry-pick.vim
+++ b/syntax/twiggy-cherry-pick.vim
@@ -1,0 +1,1 @@
+twiggy-rebase.vim

--- a/syntax/twiggy-help.vim
+++ b/syntax/twiggy-help.vim
@@ -1,0 +1,12 @@
+syntax match TwiggyQuickhelpMapping "\v%<7c[A-Za-z\-\?\^\<\>!,]"
+highlight link TwiggyQuickhelpMapping Identifier
+syntax match TwiggyQuickhelpSpecial "\v\`[a-zA-Z]+\`"
+highlight link TwiggyQuickhelpSpecial Identifier
+syntax match TwiggyQuickhelpHeader "\v[A-Za-z ]+\n[=]+"
+highlight link TwiggyQuickhelpHeader String
+syntax match TwiggyQuickhelpSectionHeader "\v[\-]+\n[a-z,\/ \:]+\n[\-]+"
+highlight link TwiggyQuickhelpSectionHeader String
+if g:twiggy_show_full_ui
+    syntax match TwiggyQuickhelpRecommendation "\v^\*+\n[A-Za-z\: ]+\n[a-z\:\- ]+"
+    highlight link TwiggyQuickhelpRecommendation String
+endif

--- a/syntax/twiggy-merge.vim
+++ b/syntax/twiggy-merge.vim
@@ -1,0 +1,1 @@
+twiggy-rebase.vim

--- a/syntax/twiggy-output.vim
+++ b/syntax/twiggy-output.vim
@@ -1,0 +1,4 @@
+syntax match TwiggyOutputText "\v^[^ ](.*)"
+highlight link TwiggyOutputText  Comment
+syntax match TwiggyOutputFile "\v^\t(.*)"
+highlight link TwiggyOutputFile Constant

--- a/syntax/twiggy-rebase.vim
+++ b/syntax/twiggy-rebase.vim
@@ -1,0 +1,8 @@
+syntax match TwiggyAttnModeMapping "\v%3c(s|c|a)"
+highlight link TwiggyAttnModeMapping Identifier
+
+syntax match TwiggyAttnModeTitle "\v^(rebase|merge|cherry pick) in progress"
+highlight link TwiggyAttnModeTitle Type
+
+syntax match TwiggyAttnModeInstruction "\v^from this window:"
+highlight link TwiggyAttnModeInstruction String

--- a/syntax/twiggy.vim
+++ b/syntax/twiggy.vim
@@ -1,0 +1,45 @@
+exec "syntax match TwiggyGroup '\\v(^[^\\ " . g:twiggy_icons.current . "]+)'"
+highlight default link TwiggyGroup Type
+
+exec "syntax match TwiggyCurrent '\\v%3v" . twiggy#get_current_branch() . "$'"
+highlight default link TwiggyCurrent Identifier
+
+exec "syntax match TwiggyCurrent '\\V\\%1c" . g:twiggy_icons.current . "'"
+highlight default link TwiggyCurrent Identifier
+
+exec "syntax match TwiggyTracking '\\V\\%2c" . g:twiggy_icons.tracking . "'"
+highlight default link TwiggyTracking String
+
+exec "syntax match TwiggyAhead '\\V\\%2c" . g:twiggy_icons.ahead . "'"
+highlight default link TwiggyAhead Type
+
+exec "syntax match TwiggyAheadBehind '\\V\\%2c" . g:twiggy_icons.behind . "'"
+exec "syntax match TwiggyAheadBehind '\\V\\%2c" . g:twiggy_icons.both . "'"
+highlight default link TwiggyAheadBehind Type
+
+exec "syntax match TwiggyDetached '\\V\\%2c" . g:twiggy_icons.detached . "'"
+highlight default link TwiggyDetached Type
+
+exec "syntax match TwiggyUnmerged '\\V\\%1c" . g:twiggy_icons.unmerged . "'"
+highlight default link TwiggyUnmerged Identifier
+
+syntax match TwiggySortText '\v[[a-z]+]'
+highlight default link TwiggySortText Comment
+
+if exists('b:twiggy_branches_not_in_reflog') && len(b:twiggy_branches_not_in_reflog)
+    exec "syntax match TwiggyNotInReflog '" .
+            \ twiggy#gsub(twiggy#gsub(join(b:twiggy_branches_not_in_reflog), '\(', ''), '\)', '') .
+            \ "'"
+    highlight default link TwiggyNotInReflog Comment
+endif
+
+exec "syntax match TwiggyDetachedText '\\v%3vHEAD:'"
+highlight default link TwiggyDetachedText Type
+
+if twiggy#showing_full_ui()
+    syntax match TwiggyHelpHint "\v%1l"
+    highlight default link TwiggyHelpHint Normal
+
+    syntax match TwiggyHelpHintKey "\v%1l\?"
+    highlight default link TwiggyHelpHintKey Identifier
+endif


### PR DESCRIPTION
This will (hopefully) prevent re-running code that is supposed to be executed only once (buffer local mappings, etc...) as well as clean up the code a bit. The code in the `ftplugin` directory is run on `setfiletype ...`. Also moved syntax statements under the `syntax/` directory.