### PR TITLE
Fix docs error of g:twiggy_adapt_columns

### DIFF
--- a/doc/twiggy.txt
+++ b/doc/twiggy.txt
@@ -134,7 +134,7 @@ Default: 0
 Ensures all branch names are visible in twiggy's buffer (overrides
 |'adapt_columns'|).
 >
-  let g:twiggy_num_columns = 1
+  let g:twiggy_adapt_columns = 1
 <
                                                 *'split_method'*
 Default: 'topleft'


### PR DESCRIPTION
There was a documentation error at the doc directory that used the wrong
variable name. The name of the variable was g:twiggy_adapt_columns, but
the name that was written was g:twiggy_num_columns.