### PR TITLE
Add horizontal split direction

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -84,9 +84,10 @@ let s:icons.unmerged = s:icon_set[6]
 " {{{1 Options
 
 let g:twiggy_num_columns            = get(g:,'twiggy_num_columns',            31                                                       )
+let g:twiggy_num_rows               = get(g:,'twiggy_num_rows',               31                                                       )
 let g:twiggy_adapt_columns          = get(g:,'twiggy_adapt_columns',          0                                                        )
+let g:twiggy_split_direction        = get(g:,'twiggy_split_direction',        'vertical'                                               )
 let g:twiggy_split_position         = get(g:,'twiggy_split_position',         ''                                                       )
-let g:twiggy_split_method           = get(g:,'twiggy_split_method ',          ''                                                       )
 let g:twiggy_local_branch_sort      = get(g:,'twiggy_local_branch_sort',      'alpha'                                                  )
 let g:twiggy_local_branch_sorts     = get(g:,'twiggy_local_branch_sorts',     ['alpha', 'date', 'track', 'mru']                        )
 let g:twiggy_remote_branch_sort     = get(g:,'twiggy_remote_branch_sort',     'alpha'                                                  )
@@ -840,7 +841,11 @@ function! s:Render() abort
     if &filetype ==# 'twiggyqh'
       exec "edit" fname
     else
-      exec 'silent keepalt' g:twiggy_split_position g:twiggy_num_columns . 'vsplit' fname
+      if g:twiggy_split_direction ==# "horizontal"
+        exec 'silent keepalt' g:twiggy_split_position g:twiggy_num_rows . 'split' fname
+      else
+        exec 'silent keepalt' g:twiggy_split_position g:twiggy_num_columns . 'vsplit' fname
+      endif
     endif
     setlocal filetype=twiggy buftype=nofile bufhidden=delete
     setlocal nonumber nowrap lisp
@@ -889,7 +894,7 @@ function! s:Render() abort
     call extend(output, s:standard_view())
   end
 
-  if g:twiggy_adapt_columns
+  if g:twiggy_adapt_columns && g:twiggy_split_direction !=# "horizontal"
     let cols = 0
     for line in output
       let line_length = len(line)

--- a/doc/twiggy.txt
+++ b/doc/twiggy.txt
@@ -125,17 +125,31 @@ OTHER OPTIONS                                   *twiggy-options*
 
                                                 *'num_columns'*
 Default: 31
-The width of Twiggy's buffer
+The width of Twiggy's buffer.  Only applies for vertical splits.
 >
   let g:twiggy_num_columns = 25
 <
+                                                *'num_rows'*
+Default: 31
+The height of Twiggy's buffer.  Only applies for horizontal splits.
+>
+  let g:twiggy_num_rows = 25
+<
+
                                                 *'adapt_columns'*
 Default: 0
 Ensures all branch names are visible in twiggy's buffer (overrides
-|'adapt_columns'|).
+|'adapt_columns'|).  Only applies for vertical splits.
 >
   let g:twiggy_adapt_columns = 1
 <
+                                                *'split_direction'*
+Default: 'vertical'
+The direction of the split.  Can be |vertical| or |horizontal|.
+>
+  let g:twiggy_split_direction = 'vertical'
+<
+
                                                 *'split_position'*
 Default: ''
 The split method used to show the twiggy buffer.  Can be |leftabove|,
@@ -143,8 +157,6 @@ The split method used to show the twiggy buffer.  Can be |leftabove|,
 >
   let g:twiggy_split_position = 'botright'
 <
-Twiggy only allows a vertical split.
-
                                                 *'git_log_command'*
 Default: ''
 The command to use for the `gl` mapping.  See |twiggy-git-log|.


### PR DESCRIPTION
Solves https://github.com/sodapopcan/vim-twiggy/issues/40

Enables horizontal splitting as well as vertical.

The idea is that the behaviour wouldn't change for any existing user.