### PR TITLE
Don't use deprecated fugitive commands

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -186,7 +186,7 @@ function! s:call(mapping) abort
     call <SID>buffocus(t:twiggy_bufnr)
     if s:attn_mode()
       wincmd p
-      Gstatus
+      Git
     endif
     call s:RenderOutputBuffer()
   endif
@@ -804,7 +804,7 @@ endfunction
 "     {{{3 bufrefresh
 function! s:bufrefresh()
   if &ft ==# 'gitcommit'
-    Gstatus
+    Git
   elseif &modifiable && &buftype ==# ''
     try
       silent edit
@@ -1489,6 +1489,6 @@ function! s:close_string() abort
   endif
 endfunction
 
-autocmd BufEnter twiggy://* exec "command! -buffer Gstatus " . <SID>close_string() . " | silent normal! :<\C-U>Gstatus\<CR>"
-autocmd BufEnter twiggy://* exec "command! -buffer Gcommit " . <SID>close_string() . " | silent normal! :<\C-U>Gcommit\<CR>"
-autocmd BufEnter twiggy://* exec "command! -buffer Gblame  " . <SID>close_string() . " | silent normal! :<\C-U>Gblame\<CR>"
+autocmd BufEnter twiggy://* exec "command! -buffer Git " . <SID>close_string() . " | silent normal! :<\C-U>Git\<CR>"
+autocmd BufEnter twiggy://* exec "command! -buffer Git commit " . <SID>close_string() . " | silent normal! :<\C-U>Git commit\<CR>"
+autocmd BufEnter twiggy://* exec "command! -buffer Git blame  " . <SID>close_string() . " | silent normal! :<\C-U>Git blame\<CR>"


### PR DESCRIPTION
:Gstatus has been removed in favor of :Git and all other :Gxxx comamnds
are now :Git xxx