### PR TITLE
Don't crash on commits with empty messages

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -198,7 +198,7 @@ endfunction
 function! s:parse_branch(branch, type) abort
   let branch = {}
 
-  let pieces = split(a:branch, "\t\t")
+  let pieces = split(a:branch, "\t\t", 1)
 
   let branch.current = pieces[0] ==# "*"
 


### PR DESCRIPTION
Ask split() to keep empty fields while parsing branch information.

Before this patch, twiggy would crash while trying to access pieces[5]
if the latest commit of a branch had an empty message.